### PR TITLE
fix: モバイルビューポート高さ問題とボトムシート動作の改善

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12882,9 +12882,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9017,14 +9017,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -70,8 +70,8 @@
     background-attachment: fixed;
     /* 画面全体にフィット */
     background-size: 100% 100%;
-    /* 画面全体にの最小高さ */
-    min-height: 100vh;
+    /* 画面全体にの最小高さ（モバイルブラウザのアドレスバー考慮） */
+    min-height: 100dvh;
   }
 
   /* 他にもh1やaタグなどのデフォルトスタイルをここで定義できる */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,6 +51,11 @@
   /* ヘッダー専用フォントウェイト */
   --font-weight-header-logo: 600;
   --font-weight-header-nav: 500;
+
+  /* レイアウト関連 (layout) */
+  --header-height: 4rem;
+  --sidebar-width-min: 32rem;
+  --sidebar-width-max: 42rem;
 }
 
 /* ---------------------------------- */

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
 
 export default function LibraryPage() {
   return (
-    <div className="bg-background min-h-screen">
+    <div className="bg-background min-h-dvh">
       <main className="container mx-auto px-6 py-8">
         <div className="mx-auto max-w-4xl">
           {/* ページヘッダー */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,7 @@ import { MobileInteractionWrapper } from '@/components/layouts/MobileBottomSheet
  */
 export default function Home() {
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-[calc(100dvh-4rem)] flex-col">
       {/* 2-column layout: Side Panel + Canvas */}
       <main className="flex flex-1">
         {/* Left: Side Panel - デスクトップ（md以上）のみ表示 */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,12 +19,12 @@ import { MobileInteractionWrapper } from '@/components/layouts/MobileBottomSheet
  */
 export default function Home() {
   return (
-    <div className="flex h-[calc(100dvh-4rem)] flex-col">
+    <div className="flex h-[calc(100dvh-var(--header-height))] flex-col">
       {/* 2-column layout: Side Panel + Canvas */}
       <main className="flex flex-1">
         {/* デスクトップ */}
         {/* Left: Side Panel */}
-        <SidePanel className="hidden w-fit max-w-[42rem] min-w-[32rem] pl-8 md:block" />
+        <SidePanel className="hidden w-fit max-w-[var(--sidebar-width-max)] min-w-[var(--sidebar-width-min)] pl-8 md:block" />
         {/* Right: Canvas */}
         <Canvas className="hidden flex-1 md:block" />
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,20 +22,17 @@ export default function Home() {
     <div className="flex h-[calc(100dvh-4rem)] flex-col">
       {/* 2-column layout: Side Panel + Canvas */}
       <main className="flex flex-1">
-        {/* Left: Side Panel - デスクトップ（md以上）のみ表示 */}
+        {/* デスクトップ */}
+        {/* Left: Side Panel */}
         <SidePanel className="hidden w-fit max-w-[42rem] min-w-[32rem] pl-8 md:block" />
+        {/* Right: Canvas */}
+        <Canvas className="hidden flex-1 md:block" />
 
-        {/* Right: Canvas - 残り領域を使用 */}
-        {/* モバイルの時だけインタラクティブな部分をラッパーで囲む。 */}
+        {/* モバイル */}
         <div className="flex-1 md:hidden">
           <MobileInteractionWrapper>
             <Canvas className="flex-1" />
           </MobileInteractionWrapper>
-        </div>
-
-        {/* デスクトップの時は、Canvasはインタラクション不要 */}
-        <div className="hidden flex-1 md:block">
-          <Canvas className="flex-1" />
         </div>
       </main>
     </div>

--- a/src/app/tutorial/page.tsx
+++ b/src/app/tutorial/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
 
 export default function TutorialPage() {
   return (
-    <div className="bg-background min-h-screen">
+    <div className="bg-background min-h-dvh">
       <main className="container mx-auto px-6 py-8">
         <div className="mx-auto max-w-4xl">
           {/* ページヘッダー */}

--- a/src/components/layouts/Canvas/components/HubTypeController.tsx
+++ b/src/components/layouts/Canvas/components/HubTypeController.tsx
@@ -18,10 +18,10 @@ export const HubTypeController: React.FC = () => {
   const { hubType } = useHubStore();
 
   useEffect(() => {
-    const container = document.querySelector('.hub-container');
-    if (container) {
+    const containers = document.querySelectorAll('.hub-container');
+    containers.forEach(container => {
       container.setAttribute('data-hub-type', hubType);
-    }
+    });
   }, [hubType]);
 
   // レンダリングしない（純粋なDOM操作コンポーネント）

--- a/src/components/layouts/GlobalHeader/components/GlobalHeader.tsx
+++ b/src/components/layouts/GlobalHeader/components/GlobalHeader.tsx
@@ -22,7 +22,7 @@ const navigationLinks: NavigationLink[] = [
  */
 export const GlobalHeader: React.FC = () => {
   return (
-    <header className="border-header-border bg-bg-from relative flex min-h-[4rem] w-full items-center border-b px-6 py-4 lg:px-8">
+    <header className="border-header-border bg-bg-from relative flex min-h-[var(--header-height)] w-full items-center border-b px-6 py-4 lg:px-8">
       {/* ロゴエリア - 左端配置、Hubページへのリンク */}
       <div className="flex-1">
         <Logo />

--- a/src/components/layouts/MobileBottomSheet/components/MobileBottomSheet.tsx
+++ b/src/components/layouts/MobileBottomSheet/components/MobileBottomSheet.tsx
@@ -32,10 +32,15 @@ export const MobileBottomSheet: React.FC<MobileBottomSheetProps> = ({
       activeSnapPoint={activeSnapPoint}
       setActiveSnapPoint={setActiveSnapPoint}
       snapPoints={[SNAP_POINTS.LOWEST, SNAP_POINTS.HALF, SNAP_POINTS.EXPANDED]}
+      closeThreshold={0.25}
+      scrollLockTimeout={100}
       defaultOpen
     >
       <VaulDrawer.Portal>
-        <VaulDrawer.Overlay className="pointer-events-none fixed inset-0 z-50 bg-black/40" />
+        <VaulDrawer.Overlay
+          className="fixed inset-0 z-50 bg-black/40"
+          onClick={() => setActiveSnapPoint(SNAP_POINTS.LOWEST)}
+        />
         <VaulDrawer.Content
           className={cn(
             'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-full flex-col rounded-t-[10px] border',

--- a/src/components/layouts/MobileBottomSheet/components/MobileBottomSheet.tsx
+++ b/src/components/layouts/MobileBottomSheet/components/MobileBottomSheet.tsx
@@ -32,8 +32,8 @@ export const MobileBottomSheet: React.FC<MobileBottomSheetProps> = ({
       activeSnapPoint={activeSnapPoint}
       setActiveSnapPoint={setActiveSnapPoint}
       snapPoints={[SNAP_POINTS.LOWEST, SNAP_POINTS.HALF, SNAP_POINTS.EXPANDED]}
-      closeThreshold={0.25}
-      scrollLockTimeout={100}
+      closeThreshold={0.25} // ドローワーの高さの25%がドラッグされると閉じる
+      scrollLockTimeout={100} // スクロールロックが適用されるまでの遅延時間
       defaultOpen
     >
       <VaulDrawer.Portal>

--- a/src/components/layouts/MobileBottomSheet/components/MobileInteractionWrapper.tsx
+++ b/src/components/layouts/MobileBottomSheet/components/MobileInteractionWrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { MobileBottomSheet } from './MobileBottomSheet';
 import { SNAP_POINTS, TABS } from '../constants';
 
@@ -22,6 +22,25 @@ export function MobileInteractionWrapper({ children }: MobileInteractionWrapperP
       setActiveSnapPoint(SNAP_POINTS.LOWEST);
     }
   }, [activeSnapPoint, setActiveSnapPoint]);
+
+  // ボトムシートが開いている時に背景スクロールを無効化
+  useEffect(() => {
+    if (activeSnapPoint !== SNAP_POINTS.LOWEST) {
+      // ボトムシートが開いている場合、背景スクロールを無効化
+      document.body.style.overflow = 'hidden';
+      document.body.style.touchAction = 'none';
+    } else {
+      // ボトムシートが閉じている場合、背景スクロールを有効化
+      document.body.style.overflow = '';
+      document.body.style.touchAction = '';
+    }
+
+    // クリーンアップ
+    return () => {
+      document.body.style.overflow = '';
+      document.body.style.touchAction = '';
+    };
+  }, [activeSnapPoint]);
 
   return (
     <>


### PR DESCRIPTION
<\!-- レビューは日本語で行うこと -->

# Overview

モバイル環境でのビューポート高さ問題とボトムシートの動作に関する問題を修正しました。

## Related Issues

- 関連Issueなし

## Changes

- **ビューポート高さ問題の修正**: Safari（iOS）やChrome（Android）でのURLバー表示・非表示による画面高さ変化に対応するため、`vh`単位を`dvh`単位に変更
- **ボトムシートスナップ動作の改善**: 下向きスワイプ時にシートが消えてしまう問題を修正し、適切にLOWESTポジションにスナップするよう調整
- **背景スクロール制御**: ボトムシート展開時の背景スクロールを無効化
- **オーバーレイクリック機能**: ボトムシート外をタップした際にシートを閉じる機能を追加

## Type of Change

- [x] 🐛 Bug fix (a non-breaking change which fixes an issue)

## Screenshots

動作確認済み：
- スマートフォンでのビューポート高さ変化に対する安定性
- ボトムシートのスナップ動作
- 背景スクロール制御
- オーバーレイクリック機能

## Self-Review Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Additional Comments

主要な技術的変更点：
1. CSS単位の変更: `vh` → `dvh`, `h-screen` → `h-dvh`
2. Vaul設定の調整: `dismissible={false}`, `closeThreshold={0.25}`, `scrollLockTimeout={100}`
3. 動的スタイル制御: `document.body.style.overflow`と`touchAction`の制御
4. オーバーレイクリックハンドラーの追加

これらの変更により、モバイル環境でのユーザー体験が大幅に向上しました。