### PR TITLE
feat(domain): introduce IMusicalContext abstraction

### DIFF
--- a/docs/10.domain/03.domainSystem.md
+++ b/docs/10.domain/03.domainSystem.md
@@ -17,6 +17,7 @@
 - **スケール理論**: 音階の構造とモーダルな関係性
 - **コード理論**: 和音の構造と機能的役割
 - **調性理論**: キーと和声機能の体系
+- **旋風理論**: モード体系
 
 ---
 
@@ -26,16 +27,18 @@
 
 ### 2.1. オブジェクト一覧（概要）
 
-| オブジェクト名     | 区分           | 責務                                         | たとえ             |
-| :----------------- | :------------- | :------------------------------------------- | :----------------- |
-| **`PitchClass`**   | 値オブジェクト | オクターブに依存しない12の音名を表現         | 色の名前           |
-| **`Interval`**     | 値オブジェクト | 2音間の相対的な距離（関係性）を定義          | ものさし           |
-| **`Note`**         | 値オブジェクト | 具体的な音の高さ（ピッチ+オクターブ）を表現  | 特定の絵の具       |
-| **`ScalePattern`** | 値オブジェクト | あらゆる音階の構造を定義する設計図           | 建築設計図         |
-| **`ChordPattern`** | 値オブジェクト | あらゆる和音の構造を定義する設計図           | 家具設計図         |
-| **`Scale`**        | 集約           | 特定のルート音から生成された具体的な音階     | 完成した建物       |
-| **`Chord`**        | 集約           | 同時に鳴る音の集合（和音）                   | 完成した家具       |
-| **`Key`**          | 集約           | 音楽全体の文脈と重力場を定義する調性システム | 都市の統治システム |
+| オブジェクト名        | 区分             | 責務                                               | たとえ       |
+| :-------------------- | :--------------- | :------------------------------------------------- | :----------- |
+| **`PitchClass`**      | 値オブジェクト   | オクターブに依存しない12の音名を表現               | 色の名前     |
+| **`Interval`**        | 値オブジェクト   | 2音間の相対的な距離（関係性）を定義                | ものさし     |
+| **`Note`**            | 値オブジェクト   | 具体的な音の高さ（ピッチ+オクターブ）を表現        | 特定の絵の具 |
+| **`ScalePattern`**    | 値オブジェクト   | あらゆる音階の構造を定義する設計図                 | 建築設計図   |
+| **`ChordPattern`**    | 値オブジェクト   | あらゆる和音の構造を定義する設計図                 | 家具設計図   |
+| **`Scale`**           | 集約             | 特定のルート音から生成された具体的な音階           | 完成した建物 |
+| **`Chord`**           | 集約             | 同時に鳴る音の集合（和音）                         | 完成した家具 |
+| **`IMusicalContext`** | インターフェース | あらゆる音楽的「世界」が持つべき共通の契約         | 国家憲法     |
+| **`Key`**             | 集約             | 機能和声に基づく音楽の文脈を定義する調性システム   | 中央集権国家 |
+| **`ModalContext`**    | 集約             | 旋律的響きに基づく音楽の文脈を定義する旋法システム | 自由な共同体 |
 
 ### 2.2. 値オブジェクト (Value Objects)
 
@@ -162,11 +165,31 @@ class ChordPattern {
 }
 ```
 
-### 2.3. 集約 (Aggregates)
+### 2.3. インターフェース：音楽的文脈 (Musical Contexts)
+
+音楽における「世界」を定義するため、IMusicalContextインターフェースを導入する。これにより、アプリケーションは具体的な文脈（調性か旋法か）を意識することなく、抽象的な「音楽的文脈」として一貫して扱えるようになる。
+
+#### 2.3.1. IMusicalContext（音楽的文脈インターフェース）
+
+**責務**: KeyやModalContextなど、あらゆる音楽的文脈が実装すべき共通の契約を定義する。
+
+```typescript
+interface IMusicalContext<T extends IAnalysisResult = IAnalysisResult> {
+  readonly centerPitch: PitchClass; // 中心音（調性音楽のトニック、旋法音楽の中心音）
+  readonly scale: Scale;
+
+  get diatonicChords(): readonly Chord[];
+  analyzeChord(chord: Chord): T; // 型安全な分析結果を返す
+}
+```
+
+>
+
+### 2.4. 集約 (Aggregates)
 
 集約は、値オブジェクトを組み合わせて音楽理論の複合概念を表現し、一貫性の境界を定義する。
 
-#### 2.3.1. Scale（具体的な音階）
+#### 2.4.1. Scale（具体的な音階）
 
 **責務**: ルート音とパターンから構成される具体的な音階を管理する。
 
@@ -189,7 +212,7 @@ class Scale {
 }
 ```
 
-#### 2.3.2. Chord（和音）
+#### 2.4.2. Chord（和音）
 
 **責務**: ルート音とパターンから構成される和音を管理する。
 
@@ -213,44 +236,57 @@ class Chord {
 }
 ```
 
-#### 2.3.3. Key（調性）
+#### 2.4.3. Key（調性）
 
-**責務**: 調性システムの中核として、和声的文脈と機能的関係性を管理する。
+**責務**: 機能和声（Functional Harmony）のルールセットに基づき、音楽の調性的な文脈と機能的関係性を管理する。IMusicalContextを実装する。
 
 **音楽理論的背景**:
 
+- メジャー、またはマイナー（和声的短音階を含む）スケールに限定される
 - 調的重力場（Tonal Gravity）の概念
-- ダイアトニック和音の自動生成
+- ダイアトニック和音の機能（トニック、ドミナント、サブドミナント）
 - 関係調（平行調・同主調・属調・下属調）の体系
-- セカンダリー・ドミナントとノン・ダイアトニック和音
 
 **主要な振る舞い**:
 
 ```typescript
-class Key {
-  readonly tonic: PitchClass;
+class Key implements IMusicalContext {
+  readonly centerPitch: PitchClass;
   readonly scale: Scale;
-  readonly keySignature: 'sharp' | 'flat';
 
-  // ダイアトニック和音生成
-  get diatonicChords(): readonly DiatonicChordInfo[];
-  getDiatonicChord(degree: number): Chord;
+  // IMusicalContextの契約
+  diatonicChords(): readonly Chord[];
+  analyzeChord(chord: Chord): TonalChordAnalysisResult;
 
-  // 機能和音取得
-  getTonicChord(): Chord;
-  getDominantChord(): Chord;
-  getSubdominantChord(): Chord;
-
-  // 分析機能
-  analyzeChord(chord: Chord): ChordAnalysisResult;
-  analyzePitchClassInKey(pitchClass: PitchClass): DegreeResult;
-
-  // 関係調
+  // Key固有の振る舞い
+  getDiatonicChordsInfo(): Chord;
   getRelatedKeys(): RelatedKeysInfo;
 }
 ```
 
----
+#### 2.4.4. ModalContext（旋法）
+
+**責務**: 特定の旋法（モード）に基づき、音楽の旋法的な文脈と響きのキャラクターを管理する。IMusicalContextを実装する。
+
+**音楽理論的背景**:
+
+- ドリアン、フリジアンなど、あらゆるスケールパターンを扱える
+- 機能和声の強い引力（V7→I）を前提としない
+- 中心音（Tonal Center）は存在するが、コード間の関係はより水平的
+- 各コードが持つのは「機能」ではなく、旋法の響きを特徴づける「キャラクター」
+
+**主要な振る舞い**:
+
+```typescript
+class ModalContext implements IMusicalContext {
+  readonly centerPitch: PitchClass;
+  readonly scale: Scale;
+
+  // IMusicalContextの契約
+  getDiatonicChords(): readonly Chord[];
+  analyzeChord(chord: Chord): ModalChordAnalysisResult;
+}
+```
 
 ## 3. ドメインモデル関連図
 
@@ -266,10 +302,18 @@ graph TB
         CP[ChordPattern<br/>コード設計図]
     end
 
+    subgraph "Interface"
+        IMC["IMusicalContext<br/>(Interface)"]
+    end
+
     subgraph "構造物 (Aggregates)"
         SC[Scale<br/>具体的な音階]
         CH[Chord<br/>和音]
-        KEY[Key<br/>調性]
+
+        subgraph "音楽的文脈 (Musical Context Aggregates)"
+            KEY[Key<br/>調性]
+            MC[ModalContext<br/>旋法]
+        end
     end
 
     subgraph "ドメインサービス"
@@ -278,7 +322,11 @@ graph TB
         AE[AudioEngine<br/>音響エンジン]
     end
 
-    %% 値オブジェクト間の関係
+    %% 抽象と具象の関係
+    KEY -- implements --> IMC
+    MC -- implements --> IMC
+
+    %% 依存関係
     PC --> NOTE
     INT --> SP
     INT --> CP
@@ -286,14 +334,13 @@ graph TB
 
     %% 集約への依存
     PC --> SC
-    PC --> KEY
     SP --> SC
-    SP --> KEY
     CP --> CH
     SC --> KEY
+    SC --> MC
 
     %% サービス依存
-    KEY --> CA
+    IMC -.-> CA
     PC --> COF
     CH --> AE
     NOTE --> AE
@@ -438,6 +485,7 @@ private static readonly C = new PitchClass('C', 'C', 0, 0);
 src/
 └── domain/
     ├── common/                   # 値オブジェクト（複数集約で共有）
+    │   ├── IMusicalContext.ts   # 音楽的文脈インターフェース
     │   ├── PitchClass.ts        # 音名の定義と五度圏関係
     │   ├── Interval.ts          # 音程の定義と計算
     │   ├── Note.ts              # 絶対音高の定義
@@ -453,9 +501,13 @@ src/
     │   ├── index.ts           # Chord集約ルートとビジネスロジック
     │   └── test/              # Chord関連テスト
     │
-    ├── key/                   # Key集約（最も複雑）
+    ├── key/                   # Key集約（調性音楽文脈）
     │   ├── index.ts          # Key集約ルートと調性分析
     │   └── test/             # Key関連テスト
+    │
+    ├── modal-context/         # ModalContext集約（旋法音楽文脈）
+    │   ├── index.ts          # ModalContext集約ルートと旋法分析
+    │   └── test/             # ModalContext関連テスト
     │
     ├── services/             # ドメインサービス
     │   ├── ChordAnalyzer.ts  # 和音・進行分析サービス

--- a/src/components/layouts/__stories__/decorators/withStores.tsx
+++ b/src/components/layouts/__stories__/decorators/withStores.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import type { Decorator } from '@storybook/react';
-import { PitchClass, ScalePattern } from '@/domain/common';
 import { Key } from '@/domain/key';
 import { useCircleOfFifthsStore } from '@/features/circle-of-fifths/store';
 import { useCurrentKeyStore } from '@/stores/currentKeyStore';
@@ -9,7 +8,7 @@ import { useCurrentKeyStore } from '@/stores/currentKeyStore';
  * テスト用の標準初期化設定
  */
 const TEST_INITIAL_STATE = {
-  key: new Key(PitchClass.fromCircleOfFifths(0), ScalePattern.Major),
+  key: Key.fromCircleOfFifths(0, true),
   resetStores: true, // 各ストーリー実行前にストアをリセット
 } as const;
 

--- a/src/domain/chord/test/Chord.test.ts
+++ b/src/domain/chord/test/Chord.test.ts
@@ -9,7 +9,6 @@ import { ChordPattern } from '../../common';
 import { Note } from '../../common/Note';
 import { PitchClass } from '../../common/PitchClass';
 import { Key } from '../../key';
-import { ScalePattern } from '../../common/ScalePattern';
 
 describe('Chord', () => {
   describe('コンストラクタ（ファクトリメソッド経由）', () => {
@@ -83,9 +82,7 @@ describe('Chord', () => {
       const keyDTO = { shortName: 'C', keyName: 'C Major', fifthsIndex: 0, isMajor: true };
       const chord = Chord.fromKeyDTO(keyDTO); // C major
 
-      expect(chord.getNameFor(new Key(PitchClass.fromCircleOfFifths(0), ScalePattern.Major))).toBe(
-        'C'
-      );
+      expect(chord.getNameFor(Key.major(PitchClass.fromCircleOfFifths(0)))).toBe('C');
       expect(chord.getNotes().map(note => note.toString)).toEqual(['C4', 'E4', 'G4']);
     });
 
@@ -93,9 +90,7 @@ describe('Chord', () => {
       const keyDTO = { shortName: 'Am', keyName: 'A Minor', fifthsIndex: 3, isMajor: false }; // A minor
       const chord = Chord.fromKeyDTO(keyDTO);
 
-      expect(
-        chord.getNameFor(new Key(PitchClass.fromCircleOfFifths(3), ScalePattern.Aeolian))
-      ).toBe('Am');
+      expect(chord.getNameFor(Key.minor(PitchClass.fromCircleOfFifths(3)))).toBe('Am');
       expect(chord.getNotes().map(note => note.toString)).toEqual(['A4', 'C5', 'E5']);
     });
   });
@@ -136,9 +131,7 @@ describe('Chord', () => {
 
       const chord = Chord.fromNotes(constituentNotes);
 
-      expect(chord.getNameFor(new Key(PitchClass.fromCircleOfFifths(0), ScalePattern.Major))).toBe(
-        'C'
-      );
+      expect(chord.getNameFor(Key.major(PitchClass.fromCircleOfFifths(0)))).toBe('C');
       expect(chord.quality).toEqual(ChordPattern.MajorTriad);
       expect(chord.getNotes().map(note => note.toString)).toEqual(['C4', 'E4', 'G4']);
     });
@@ -152,9 +145,7 @@ describe('Chord', () => {
 
       const chord = Chord.fromNotes(constituentNotes);
 
-      expect(chord.getNameFor(new Key(PitchClass.fromCircleOfFifths(0), ScalePattern.Major))).toBe(
-        'Cm'
-      );
+      expect(chord.getNameFor(Key.major(PitchClass.fromCircleOfFifths(0)))).toBe('Cm');
       expect(chord.quality).toEqual(ChordPattern.MinorTriad);
       expect(chord.getNotes().map(note => note.toString)).toEqual(['C4', 'D#4', 'G4']);
     });
@@ -169,9 +160,7 @@ describe('Chord', () => {
 
       const chord = Chord.fromNotes(constituentNotes);
 
-      expect(chord.getNameFor(new Key(PitchClass.fromCircleOfFifths(0), ScalePattern.Major))).toBe(
-        'C7'
-      );
+      expect(chord.getNameFor(Key.major(PitchClass.fromCircleOfFifths(0)))).toBe('C7');
       expect(chord.quality).toEqual(ChordPattern.DominantSeventh);
       expect(chord.getNotes().map(note => note.toString)).toEqual(['C4', 'E4', 'G4', 'A#4']);
     });
@@ -185,9 +174,7 @@ describe('Chord', () => {
 
       const chord = Chord.fromNotes(constituentNotes);
 
-      expect(chord.getNameFor(new Key(PitchClass.fromCircleOfFifths(0), ScalePattern.Major))).toBe(
-        'Cdim'
-      );
+      expect(chord.getNameFor(Key.major(PitchClass.fromCircleOfFifths(0)))).toBe('Cdim');
       expect(chord.quality).toEqual(ChordPattern.DiminishedTriad);
     });
 
@@ -217,9 +204,7 @@ describe('Chord', () => {
       const rootNote = new Note(rootPitch, 4);
       const chord = Chord.from(rootNote, ChordPattern.MajorSeventh);
 
-      expect(chord.getNameFor(new Key(PitchClass.fromCircleOfFifths(0), ScalePattern.Major))).toBe(
-        'Cmaj7'
-      );
+      expect(chord.getNameFor(Key.major(PitchClass.fromCircleOfFifths(0)))).toBe('Cmaj7');
       expect(chord.getNotes().map(note => note.toString)).toEqual(['C4', 'E4', 'G4', 'B4']);
       expect(chord.constituentNotes.length).toBe(4);
     });
@@ -229,9 +214,7 @@ describe('Chord', () => {
       const rootNote = new Note(rootPitch, 4);
       const chord = Chord.from(rootNote, ChordPattern.MinorSeventh);
 
-      expect(chord.getNameFor(new Key(PitchClass.fromCircleOfFifths(0), ScalePattern.Major))).toBe(
-        'Cm7'
-      );
+      expect(chord.getNameFor(Key.major(PitchClass.fromCircleOfFifths(0)))).toBe('Cm7');
       expect(chord.getNotes().map(note => note.toString)).toEqual(['C4', 'D#4', 'G4', 'A#4']);
       expect(chord.constituentNotes.length).toBe(4);
     });
@@ -241,9 +224,7 @@ describe('Chord', () => {
       const rootNote = new Note(rootPitch, 4);
       const chord = Chord.from(rootNote, ChordPattern.DiminishedTriad);
 
-      expect(chord.getNameFor(new Key(PitchClass.fromCircleOfFifths(0), ScalePattern.Major))).toBe(
-        'Cdim'
-      );
+      expect(chord.getNameFor(Key.major(PitchClass.fromCircleOfFifths(0)))).toBe('Cdim');
       expect(chord.getNotes().map(note => note.toString)).toEqual(['C4', 'D#4', 'F#4']);
       expect(chord.constituentNotes.length).toBe(3);
     });
@@ -384,18 +365,10 @@ describe('Chord', () => {
       ];
       const progression = keyDTOs.map(keyDTO => Chord.fromKeyDTO(keyDTO));
 
-      expect(
-        progression[0].getNameFor(new Key(PitchClass.fromCircleOfFifths(0), ScalePattern.Major))
-      ).toBe('C');
-      expect(
-        progression[1].getNameFor(new Key(PitchClass.fromCircleOfFifths(3), ScalePattern.Aeolian))
-      ).toBe('Am');
-      expect(
-        progression[2].getNameFor(new Key(PitchClass.fromCircleOfFifths(11), ScalePattern.Major))
-      ).toBe('F');
-      expect(
-        progression[3].getNameFor(new Key(PitchClass.fromCircleOfFifths(1), ScalePattern.Major))
-      ).toBe('G');
+      expect(progression[0].getNameFor(Key.major(PitchClass.fromCircleOfFifths(0)))).toBe('C');
+      expect(progression[1].getNameFor(Key.minor(PitchClass.fromCircleOfFifths(3)))).toBe('Am');
+      expect(progression[2].getNameFor(Key.major(PitchClass.fromCircleOfFifths(11)))).toBe('F');
+      expect(progression[3].getNameFor(Key.major(PitchClass.fromCircleOfFifths(1)))).toBe('G');
     });
   });
 });

--- a/src/domain/common/ChordPattern.ts
+++ b/src/domain/common/ChordPattern.ts
@@ -1,7 +1,7 @@
 import { Interval } from './Interval';
 
 // コードパターンの基本的な性質を定義する型
-type ChordQuality = 'major' | 'minor' | 'diminished' | 'augmented' | 'other';
+export type ChordQuality = 'major' | 'minor' | 'diminished' | 'augmented' | 'other';
 
 /**
  * 和音の設計図（インターバルパターン）を表現する値オブジェクト

--- a/src/domain/common/IMusicalContext.ts
+++ b/src/domain/common/IMusicalContext.ts
@@ -1,0 +1,50 @@
+import type { PitchClass } from './PitchClass';
+import type { Scale } from '../scale';
+import type { Chord } from '../chord';
+
+/**
+ * 音楽的文脈インターフェース
+ *
+ * あらゆる音楽的「世界」が持つべき共通の契約を定義する。
+ * KeyやModalContextなどの具体的な音楽的文脈が実装する。
+ *
+ * このインターフェースにより、アプリケーションは具体的な文脈
+ * （調性か旋法か）を意識することなく、抽象的な「音楽的文脈」として
+ * 一貫して扱えるようになる。
+ */
+
+/**
+ * 分析結果の基底インターフェース
+ */
+export interface IAnalysisResult {
+  /** ローマ数字表記の度数名 */
+  romanDegreeName: string;
+  /** ダイアトニックコードかどうか */
+  isDiatonic: boolean;
+}
+
+/**
+ * 音楽的文脈インターフェース
+ *
+ * @template T 分析結果の型（TonalChordAnalysisResult または ModalChordAnalysisResult）
+ */
+export interface IMusicalContext<T extends IAnalysisResult = IAnalysisResult> {
+  /** 中心音（調性音楽のトニック、旋法音楽の中心音） */
+  readonly centerPitch: PitchClass;
+
+  /** この文脈で使用されるスケール */
+  readonly scale: Scale;
+
+  /**
+   * ダイアトニック和音一覧を取得する
+   * @returns この文脈におけるダイアトニック和音の配列
+   */
+  get diatonicChords(): readonly Chord[];
+
+  /**
+   * 指定された和音をこの文脈で分析する
+   * @param chord 分析対象の和音
+   * @returns 文脈固有の分析結果
+   */
+  analyzeChord(chord: Chord): T;
+}

--- a/src/domain/common/ScalePattern.ts
+++ b/src/domain/common/ScalePattern.ts
@@ -1,7 +1,7 @@
 import { Interval } from './Interval';
 
 // スケールパターンの基本的な性質を定義する型
-type ScaleQuality = 'major' | 'minor' | 'diminished' | 'other';
+export type ScaleQuality = 'major' | 'minor' | 'diminished' | 'other';
 
 /**
  * 音階の設計図（インターバルパターン）を表現する値オブジェクト

--- a/src/domain/common/index.ts
+++ b/src/domain/common/index.ts
@@ -1,4 +1,5 @@
 export * from './ChordPattern';
+export * from './IMusicalContext';
 export * from './Interval';
 export * from './Note';
 export * from './PitchClass';

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -9,6 +9,7 @@ export * from './common';
 export * from './scale';
 export * from './chord';
 export * from './key';
+export * from './modal-context';
 
 // サービス
 export * from './services';

--- a/src/domain/key/test/Key.test.ts
+++ b/src/domain/key/test/Key.test.ts
@@ -12,21 +12,19 @@ import { ChordPattern } from '../../common';
 describe('Key', () => {
   describe('constructor', () => {
     it('正常ケース: PitchClassとScalePatternから調を作成できる', () => {
-      const tonic = PitchClass.fromCircleOfFifths(0); // C
-      const pattern = ScalePattern.Major;
-      const key = new Key(tonic, pattern);
+      const centerPitch = PitchClass.fromCircleOfFifths(0); // C
+      const key = Key.major(centerPitch);
 
-      expect(key.tonic.sharpName).toBe('C');
+      expect(key.centerPitch.sharpName).toBe('C');
       expect(key.scale.pattern.name).toBe('Major');
       expect(key.keyName).toBe('C Major');
     });
 
     it('正常ケース: マイナーキーを作成できる', () => {
-      const tonic = PitchClass.fromCircleOfFifths(3); // A
-      const pattern = ScalePattern.Aeolian;
-      const key = new Key(tonic, pattern);
+      const centerPitch = PitchClass.fromCircleOfFifths(3); // A
+      const key = Key.minor(centerPitch);
 
-      expect(key.tonic.sharpName).toBe('A');
+      expect(key.centerPitch.sharpName).toBe('A');
       expect(key.scale.pattern.name).toBe('Minor');
       expect(key.keyName).toBe('A Minor');
     });
@@ -34,13 +32,11 @@ describe('Key', () => {
 
   describe('keyName getter', () => {
     it('正常ケース: キー名を正しく取得できる', () => {
-      const cMajor = new Key(
-        PitchClass.fromCircleOfFifths(0), // C
-        ScalePattern.Major
+      const cMajor = Key.major(
+        PitchClass.fromCircleOfFifths(0) // C
       );
-      const dMinor = new Key(
-        PitchClass.fromCircleOfFifths(2), // D
-        ScalePattern.Aeolian
+      const dMinor = Key.minor(
+        PitchClass.fromCircleOfFifths(2) // D
       );
 
       expect(cMajor.keyName).toBe('C Major');
@@ -48,56 +44,52 @@ describe('Key', () => {
     });
   });
 
-  describe('getDiatonicChord', () => {
+  describe('buildTriad', () => {
     it('正常ケース: C Majorの各度数のダイアトニックコードを正しく生成', () => {
-      const key = new Key(
-        PitchClass.fromCircleOfFifths(0), // C
-        ScalePattern.Major
+      const key = Key.major(
+        PitchClass.fromCircleOfFifths(0) // C
       );
 
       // I度 - C Major
-      const iChord = key.getDiatonicChord(1);
+      const iChord = key.buildTriad(1);
       expect(iChord.getNameFor(key)).toBe('C');
       expect(iChord.quality).toBe(ChordPattern.MajorTriad);
 
       // V度 - G Major
-      const vChord = key.getDiatonicChord(5);
+      const vChord = key.buildTriad(5);
       expect(vChord.getNameFor(key)).toBe('G');
       expect(vChord.quality).toBe(ChordPattern.MajorTriad);
 
       // vi度 - A Minor
-      const viChord = key.getDiatonicChord(6);
+      const viChord = key.buildTriad(6);
       expect(viChord.getNameFor(key)).toBe('Am');
       expect(viChord.quality).toBe(ChordPattern.MinorTriad);
     });
 
     it('異常ケース: 無効な度数でエラーをスロー', () => {
-      const key = new Key(
-        PitchClass.fromCircleOfFifths(0), // C
-        ScalePattern.Major
+      const key = Key.major(
+        PitchClass.fromCircleOfFifths(0) // C
       );
 
-      expect(() => key.getDiatonicChord(0)).toThrow('度数は1から7の間で指定してください。');
-      expect(() => key.getDiatonicChord(8)).toThrow('度数は1から7の間で指定してください。');
+      expect(() => key.buildTriad(0)).toThrow('度数は1から7の間で指定してください。');
+      expect(() => key.buildTriad(8)).toThrow('度数は1から7の間で指定してください。');
     });
   });
 
   describe('特定和音取得メソッド', () => {
     it('正常ケース: トニックコードを正しく取得', () => {
-      const key = new Key(
-        PitchClass.fromCircleOfFifths(0), // G
-        ScalePattern.Major
+      const key = Key.major(
+        PitchClass.fromCircleOfFifths(0) // C
       );
 
-      const tonicChord = key.getTonicChord();
-      expect(tonicChord.getNameFor(key)).toBe('C');
-      expect(tonicChord.quality).toBe(ChordPattern.MajorTriad);
+      const centerPitchChord = key.getTonicChord();
+      expect(centerPitchChord.getNameFor(key)).toBe('C');
+      expect(centerPitchChord.quality).toBe(ChordPattern.MajorTriad);
     });
 
     it('正常ケース: ドミナントコードを正しく取得', () => {
-      const key = new Key(
-        PitchClass.fromCircleOfFifths(0), // C
-        ScalePattern.Major
+      const key = Key.major(
+        PitchClass.fromCircleOfFifths(0) // C
       );
 
       const dominantChord = key.getDominantChord();
@@ -106,9 +98,8 @@ describe('Key', () => {
     });
 
     it('正常ケース: サブドミナントコードを正しく取得', () => {
-      const key = new Key(
-        PitchClass.fromCircleOfFifths(0), // C
-        ScalePattern.Major
+      const key = Key.major(
+        PitchClass.fromCircleOfFifths(0) // C
       );
 
       const subdominantChord = key.getSubdominantChord();
@@ -121,7 +112,7 @@ describe('Key', () => {
     it('正常ケース: 五度圏インデックスからメジャーキーを生成', () => {
       const key = Key.fromCircleOfFifths(1, true); // G Major
 
-      expect(key.tonic.sharpName).toBe('G');
+      expect(key.centerPitch.sharpName).toBe('G');
       expect(key.scale.pattern).toBe(ScalePattern.Major);
       expect(key.keyName).toBe('G Major');
     });
@@ -129,7 +120,7 @@ describe('Key', () => {
     it('正常ケース: 五度圏インデックスからマイナーキーを生成', () => {
       const key = Key.fromCircleOfFifths(0, false); // C Minor
 
-      expect(key.tonic.sharpName).toBe('C');
+      expect(key.centerPitch.sharpName).toBe('C');
       expect(key.scale.pattern).toBe(ScalePattern.Aeolian);
       expect(key.keyName).toBe('C Minor');
     });
@@ -144,9 +135,8 @@ describe('Key', () => {
 
   describe('primaryScale プロパティ', () => {
     it('正常ケース: 主要スケールが正しく設定される', () => {
-      const key = new Key(
-        PitchClass.fromCircleOfFifths(0), // C
-        ScalePattern.Major
+      const key = Key.major(
+        PitchClass.fromCircleOfFifths(0) // C
       );
 
       expect(key.scale.root.sharpName).toBe('C');
@@ -163,8 +153,8 @@ describe('Key', () => {
         const majorKey = Key.fromCircleOfFifths(i, true);
         const minorKey = Key.fromCircleOfFifths(i, false);
 
-        expect(majorKey.tonic.sharpName).toBe(expectedMajorKeys[i]);
-        expect(minorKey.tonic.sharpName).toBe(expectedMinorKeys[i]);
+        expect(majorKey.centerPitch.sharpName).toBe(expectedMajorKeys[i]);
+        expect(minorKey.centerPitch.sharpName).toBe(expectedMinorKeys[i]);
       }
     });
 
@@ -203,17 +193,16 @@ describe('Key', () => {
 
   describe('音楽理論的特性', () => {
     it('正常ケース: C Majorキーのダイアトニックコード進行', () => {
-      const key = new Key(
-        PitchClass.fromCircleOfFifths(0), // C
-        ScalePattern.Major
+      const key = Key.major(
+        PitchClass.fromCircleOfFifths(0) // C
       );
 
       // I-vi-IV-V進行
       const progression = [
-        key.getDiatonicChord(1), // C Major
-        key.getDiatonicChord(6), // A Minor
-        key.getDiatonicChord(4), // F Major
-        key.getDiatonicChord(5), // G Major
+        key.buildTriad(1), // C Major
+        key.buildTriad(6), // A Minor
+        key.buildTriad(4), // F Major
+        key.buildTriad(5), // G Major
       ];
 
       expect(progression[0].getNameFor(key)).toBe('C');
@@ -223,18 +212,16 @@ describe('Key', () => {
     });
 
     it('正常ケース: 相対調関係の確認', () => {
-      const cMajor = new Key(
-        PitchClass.fromCircleOfFifths(0), // C
-        ScalePattern.Major
+      const cMajor = Key.major(
+        PitchClass.fromCircleOfFifths(0) // C
       );
-      const aMinor = new Key(
-        PitchClass.fromCircleOfFifths(3), // A
-        ScalePattern.Aeolian
+      const aMinor = Key.minor(
+        PitchClass.fromCircleOfFifths(3) // A
       );
 
       // C MajorとA Minorは相対調（同じ調号）
-      expect(cMajor.tonic.sharpName).toBe('C');
-      expect(aMinor.tonic.sharpName).toBe('A');
+      expect(cMajor.centerPitch.sharpName).toBe('C');
+      expect(aMinor.centerPitch.sharpName).toBe('A');
     });
   });
 
@@ -248,90 +235,90 @@ describe('Key', () => {
 
       testKeys.forEach(({ circleIndex, name }) => {
         const key = Key.fromCircleOfFifths(circleIndex, true);
-        const tonic = key.getTonicChord();
+        const centerPitch = key.getTonicChord();
 
-        expect(tonic.rootNote._pitchClass.sharpName).toBe(name);
-        expect(tonic.quality).toBe(ChordPattern.MajorTriad);
+        expect(centerPitch.rootNote._pitchClass.sharpName).toBe(name);
+        expect(centerPitch.quality).toBe(ChordPattern.MajorTriad);
       });
     });
   });
 
   describe('getRelatedKeys メソッド', () => {
     it('正常ケース: C Majorの関連調を正しく取得', () => {
-      const cMajor = new Key(PitchClass.fromCircleOfFifths(0), ScalePattern.Major);
+      const cMajor = Key.major(PitchClass.fromCircleOfFifths(0));
       const relatedKeys = cMajor.getRelatedKeys();
 
       // 平行調: A minor (C Major の平行調)
-      expect(relatedKeys.relative.tonic.sharpName).toBe('A');
+      expect(relatedKeys.relative.centerPitch.sharpName).toBe('A');
       expect(relatedKeys.relative.isMajor).toBe(false);
       expect(relatedKeys.relative.keyName).toBe('A Minor');
 
       // 同主調: C minor (同じトニック、異なるモード)
-      expect(relatedKeys.parallel.tonic.sharpName).toBe('C');
+      expect(relatedKeys.parallel.centerPitch.sharpName).toBe('C');
       expect(relatedKeys.parallel.isMajor).toBe(false);
       expect(relatedKeys.parallel.keyName).toBe('C Minor');
 
       // 属調: G major (V度のキー)
-      expect(relatedKeys.dominant.tonic.sharpName).toBe('G');
+      expect(relatedKeys.dominant.centerPitch.sharpName).toBe('G');
       expect(relatedKeys.dominant.isMajor).toBe(true);
       expect(relatedKeys.dominant.keyName).toBe('G Major');
 
       // 下属調: F major (IV度のキー)
-      expect(relatedKeys.subdominant.tonic.sharpName).toBe('F');
+      expect(relatedKeys.subdominant.centerPitch.sharpName).toBe('F');
       expect(relatedKeys.subdominant.isMajor).toBe(true);
       expect(relatedKeys.subdominant.keyName).toBe('F Major');
     });
 
     it('正常ケース: A minorの関連調を正しく取得', () => {
-      const aMinor = new Key(PitchClass.fromCircleOfFifths(3), ScalePattern.Aeolian);
+      const aMinor = Key.minor(PitchClass.fromCircleOfFifths(3));
       const relatedKeys = aMinor.getRelatedKeys();
 
       // 平行調: C major (A minor の平行調)
-      expect(relatedKeys.relative.tonic.sharpName).toBe('C');
+      expect(relatedKeys.relative.centerPitch.sharpName).toBe('C');
       expect(relatedKeys.relative.isMajor).toBe(true);
       expect(relatedKeys.relative.keyName).toBe('C Major');
 
       // 同主調: A major (同じトニック、異なるモード)
-      expect(relatedKeys.parallel.tonic.sharpName).toBe('A');
+      expect(relatedKeys.parallel.centerPitch.sharpName).toBe('A');
       expect(relatedKeys.parallel.isMajor).toBe(true);
       expect(relatedKeys.parallel.keyName).toBe('A Major');
 
       // 属調: E minor (V度のキー)
-      expect(relatedKeys.dominant.tonic.sharpName).toBe('E');
+      expect(relatedKeys.dominant.centerPitch.sharpName).toBe('E');
       expect(relatedKeys.dominant.isMajor).toBe(false);
       expect(relatedKeys.dominant.keyName).toBe('E Minor');
 
       // 下属調: D minor (IV度のキー)
-      expect(relatedKeys.subdominant.tonic.sharpName).toBe('D');
+      expect(relatedKeys.subdominant.centerPitch.sharpName).toBe('D');
       expect(relatedKeys.subdominant.isMajor).toBe(false);
       expect(relatedKeys.subdominant.keyName).toBe('D Minor');
     });
 
     it('境界値ケース: フラット系キー(F# Major)の関連調', () => {
-      const fsSharpMajor = new Key(PitchClass.fromCircleOfFifths(6), ScalePattern.Major);
+      const fsSharpMajor = Key.major(PitchClass.fromCircleOfFifths(6));
       const relatedKeys = fsSharpMajor.getRelatedKeys();
 
       // 平行調: D# minor
-      expect(relatedKeys.relative.tonic.sharpName).toBe('D#');
+      expect(relatedKeys.relative.centerPitch.sharpName).toBe('D#');
       expect(relatedKeys.relative.isMajor).toBe(false);
 
       // 同主調: F# minor
-      expect(relatedKeys.parallel.tonic.sharpName).toBe('F#');
+      expect(relatedKeys.parallel.centerPitch.sharpName).toBe('F#');
       expect(relatedKeys.parallel.isMajor).toBe(false);
 
       // 属調: C# major
-      expect(relatedKeys.dominant.tonic.sharpName).toBe('C#');
+      expect(relatedKeys.dominant.centerPitch.sharpName).toBe('C#');
       expect(relatedKeys.dominant.isMajor).toBe(true);
 
       // 下属調: B major
-      expect(relatedKeys.subdominant.tonic.sharpName).toBe('B');
+      expect(relatedKeys.subdominant.centerPitch.sharpName).toBe('B');
       expect(relatedKeys.subdominant.isMajor).toBe(true);
     });
   });
 
   describe('japaneseScaleDegreeNames getter', () => {
     it('正常ケース: メジャーキーの日本語度数名配列を正しく返す', () => {
-      const cMajor = new Key(PitchClass.fromCircleOfFifths(0), ScalePattern.Major);
+      const cMajor = Key.major(PitchClass.fromCircleOfFifths(0));
       const majorDegreeNames = cMajor.japaneseScaleDegreeNames;
 
       expect(majorDegreeNames).toEqual([
@@ -347,7 +334,7 @@ describe('Key', () => {
     });
 
     it('正常ケース: マイナーキーの日本語度数名配列を正しく返す', () => {
-      const aMinor = new Key(PitchClass.fromCircleOfFifths(3), ScalePattern.Aeolian);
+      const aMinor = Key.minor(PitchClass.fromCircleOfFifths(3));
       const minorDegreeNames = aMinor.japaneseScaleDegreeNames;
 
       expect(minorDegreeNames).toEqual([
@@ -363,14 +350,14 @@ describe('Key', () => {
     });
 
     it('正常ケース: 異なるメジャーキーでも同じ度数名を返す', () => {
-      const cMajor = new Key(PitchClass.fromCircleOfFifths(0), ScalePattern.Major);
-      const gMajor = new Key(PitchClass.fromCircleOfFifths(1), ScalePattern.Major);
+      const cMajor = Key.major(PitchClass.fromCircleOfFifths(0));
+      const gMajor = Key.major(PitchClass.fromCircleOfFifths(1));
 
       expect(cMajor.japaneseScaleDegreeNames).toEqual(gMajor.japaneseScaleDegreeNames);
     });
 
     it('正常ケース: 常に同じ参照を返す（メジャーキー）', () => {
-      const cMajor = new Key(PitchClass.fromCircleOfFifths(0), ScalePattern.Major);
+      const cMajor = Key.major(PitchClass.fromCircleOfFifths(0));
       const degreeNames1 = cMajor.japaneseScaleDegreeNames;
       const degreeNames2 = cMajor.japaneseScaleDegreeNames;
 
@@ -379,7 +366,7 @@ describe('Key', () => {
     });
 
     it('正常ケース: 常に同じ参照を返す（マイナーキー）', () => {
-      const aMinor = new Key(PitchClass.fromCircleOfFifths(3), ScalePattern.Aeolian);
+      const aMinor = Key.minor(PitchClass.fromCircleOfFifths(3));
       const degreeNames1 = aMinor.japaneseScaleDegreeNames;
       const degreeNames2 = aMinor.japaneseScaleDegreeNames;
 

--- a/src/domain/modal-context/index.ts
+++ b/src/domain/modal-context/index.ts
@@ -1,0 +1,74 @@
+import { PitchClass } from '../common/PitchClass';
+import { ScalePattern } from '../common/ScalePattern';
+import { Scale } from '../scale';
+import { Chord } from '../chord';
+import type { IMusicalContext, IAnalysisResult } from '../common/IMusicalContext';
+
+/**
+ * ModalContext（旋法的文脈）
+ *
+ * IMusicalContextインターフェースを実装するシンプルな旋法文脈クラス。
+ * 最小限の実装で、基本的なインターフェース要件のみを満たす。
+ */
+export class ModalContext implements IMusicalContext<IAnalysisResult> {
+  /** 中心音（Tonal Center） */
+  public readonly tonalCenter: PitchClass;
+
+  /** この文脈で使用されるスケール */
+  public readonly scale: Scale;
+
+  /**
+   * ModalContextを生成する
+   * @param tonalCenter 中心音となる音名
+   * @param scalePattern モードのスケールパターン
+   */
+  constructor(tonalCenter: PitchClass, scalePattern: ScalePattern) {
+    this.tonalCenter = tonalCenter;
+    this.scale = new Scale(tonalCenter, scalePattern);
+  }
+
+  /**
+   * IMusicalContextインターフェース実装 - centerPitch
+   */
+  get centerPitch(): PitchClass {
+    return this.tonalCenter;
+  }
+
+  /**
+   * IMusicalContextインターフェース実装 - getDiatonicChords
+   * 基本的なダイアトニック和音一覧を返す
+   */
+  getDiatonicChords(): readonly Chord[] {
+    // 基本実装：スケールの各度数に対して三和音を生成
+    const scaleNotes = this.scale.getNotes().slice(0, 7);
+    const chords: Chord[] = [];
+
+    for (let i = 0; i < 7; i++) {
+      const root = scaleNotes[i];
+      const third = scaleNotes[(i + 2) % 7];
+      const fifth = scaleNotes[(i + 4) % 7];
+
+      try {
+        const chord = Chord.fromNotes([root, third, fifth]);
+        chords.push(chord);
+      } catch {
+        // 認識できないコード品質の場合はスキップ
+        continue;
+      }
+    }
+
+    return Object.freeze(chords);
+  }
+
+  /**
+   * IMusicalContextインターフェース実装 - analyzeChord
+   * 最小限のコード分析を提供
+   */
+  analyzeChord(_chordToAnalyze: Chord): IAnalysisResult {
+    // 最小限の実装
+    return {
+      romanDegreeName: 'I', // 簡略化
+      isDiatonic: true, // 簡略化
+    };
+  }
+}

--- a/src/domain/services/ChordAnalyzer.ts
+++ b/src/domain/services/ChordAnalyzer.ts
@@ -1,4 +1,4 @@
-import { Key, ScalePattern } from '..';
+import { Key } from '..'; // Removed ScalePattern - using Key factory methods now;
 import { Chord } from '../chord';
 import { Interval, Note, PitchClass } from '../common';
 
@@ -180,7 +180,7 @@ export function printAnalysis(
 ) {
   const gravity = analyzer.calculateGravity(chord, keyRoot);
   const inertia = analyzer.calculateInertia(chord, nextChord);
-  const cMajar = new Key(PitchClass.C, ScalePattern.Major);
+  const cMajar = Key.major(PitchClass.C);
 
   console.log(
     `--- Analysis for Chord [${chord.getNameFor(cMajar)}] in Key [${keyRoot.sharpName}] ---`

--- a/src/features/information-panel/__stories__/CurrentKeyInfo.stories.tsx
+++ b/src/features/information-panel/__stories__/CurrentKeyInfo.stories.tsx
@@ -4,7 +4,6 @@ import { CurrentKeyInfo } from '../components/CurrentKeyInfo';
 import { useCurrentKeyStore } from '@/stores/currentKeyStore';
 import { Key } from '@/domain/key';
 import { PitchClass } from '@/domain/common/PitchClass';
-import { ScalePattern } from '@/domain/common/ScalePattern';
 
 const meta: Meta<typeof CurrentKeyInfo> = {
   title: 'Features/InformationPanel/CurrentKeyInfo',
@@ -85,7 +84,7 @@ export const DifferentKey: Story = {
   decorators: [
     Story => {
       // G Majorキーに設定
-      const gMajorKey = new Key(PitchClass.G, ScalePattern.Major);
+      const gMajorKey = Key.major(PitchClass.G);
       useCurrentKeyStore.getState().setCurrentKey(gMajorKey);
 
       return (
@@ -126,7 +125,7 @@ export const MinorKey: Story = {
   decorators: [
     Story => {
       // A minorキーに設定
-      const aMinorKey = new Key(PitchClass.A, ScalePattern.Aeolian);
+      const aMinorKey = Key.minor(PitchClass.A);
       useCurrentKeyStore.getState().setCurrentKey(aMinorKey);
 
       return (

--- a/src/features/information-panel/__stories__/SelectedElementInfo.stories.tsx
+++ b/src/features/information-panel/__stories__/SelectedElementInfo.stories.tsx
@@ -7,7 +7,6 @@ import { Key, KeyDTO } from '@/domain/key';
 import { Chord } from '@/domain/chord';
 import { PitchClass } from '@/domain/common/PitchClass';
 import { Note } from '@/domain/common/Note';
-import { ScalePattern } from '@/domain/common/ScalePattern';
 import { ChordPattern } from '@/domain/common/ChordPattern';
 
 // ストーリー用ヘルパー関数：C Majorキー内でのコードの正しい位置を計算
@@ -150,7 +149,7 @@ export const WithSelectedChord: Story = {
   decorators: [
     Story => {
       // C Majorキーを設定
-      const cMajorKey = new Key(PitchClass.C, ScalePattern.Major);
+      const cMajorKey = Key.major(PitchClass.C);
       useCurrentKeyStore.getState().setCurrentKey(cMajorKey);
 
       // Gコードを選択状態に設定
@@ -217,7 +216,7 @@ export const WithMinorChord: Story = {
   decorators: [
     Story => {
       // C Majorキーを設定
-      const cMajorKey = new Key(PitchClass.C, ScalePattern.Major);
+      const cMajorKey = Key.major(PitchClass.C);
       useCurrentKeyStore.getState().setCurrentKey(cMajorKey);
 
       // Aminorコードを選択状態に設定
@@ -267,7 +266,7 @@ export const WithDiminishedChord: Story = {
   decorators: [
     Story => {
       // C Majorキーを設定
-      const cMajorKey = new Key(PitchClass.C, ScalePattern.Major);
+      const cMajorKey = Key.major(PitchClass.C);
       useCurrentKeyStore.getState().setCurrentKey(cMajorKey);
 
       // Bdimコードを選択状態に設定
@@ -321,7 +320,7 @@ export const DifferentKeyContext: Story = {
   decorators: [
     Story => {
       // A minorキーを設定
-      const aMinorKey = new Key(PitchClass.A, ScalePattern.Aeolian);
+      const aMinorKey = Key.minor(PitchClass.A);
       useCurrentKeyStore.getState().setCurrentKey(aMinorKey);
 
       // Gコードを選択状態に設定
@@ -366,7 +365,7 @@ export const AccessibilityTest: Story = {
   decorators: [
     Story => {
       // C Majorキーを設定
-      const cMajorKey = new Key(PitchClass.C, ScalePattern.Major);
+      const cMajorKey = Key.major(PitchClass.C);
       useCurrentKeyStore.getState().setCurrentKey(cMajorKey);
 
       // Cコードを選択状態に設定

--- a/src/features/information-panel/hooks/useCurrentKeyData.ts
+++ b/src/features/information-panel/hooks/useCurrentKeyData.ts
@@ -36,7 +36,7 @@ export const useCurrentKeyData = () => {
   /**
    * ダイアトニックコード情報配列
    */
-  const diatonicChords = useMemo(() => currentKey.diatonicChords, [currentKey]);
+  const diatonicChords = useMemo(() => currentKey.getDiatonicChordsInfo(), [currentKey]);
 
   /**
    * 関連調情報

--- a/src/stores/test/currentScaleStore.test.ts
+++ b/src/stores/test/currentScaleStore.test.ts
@@ -15,7 +15,7 @@ describe('currentKeyStore', () => {
   it('初期状態はC Majorキーである', () => {
     const { result } = renderHook(() => useCurrentKeyStore());
 
-    expect(result.current.currentKey.tonic.sharpName).toBe('C');
+    expect(result.current.currentKey.centerPitch.sharpName).toBe('C');
     expect(result.current.currentKey.isMajor).toBe(true);
     expect(result.current.currentKey.keyName).toBe('C Major');
   });
@@ -28,7 +28,7 @@ describe('currentKeyStore', () => {
       result.current.setCurrentKey(newKey);
     });
 
-    expect(result.current.currentKey.tonic.sharpName).toBe('G');
+    expect(result.current.currentKey.centerPitch.sharpName).toBe('G');
     expect(result.current.currentKey.isMajor).toBe(true);
     expect(result.current.currentKey.keyName).toBe('G Major');
   });
@@ -45,14 +45,14 @@ describe('currentKeyStore', () => {
       result.current.setCurrentKey(Key.fromCircleOfFifths(4, false)); // E Minor
     });
 
-    expect(result.current.currentKey.tonic.sharpName).toBe('E');
+    expect(result.current.currentKey.centerPitch.sharpName).toBe('E');
 
     // デフォルトにリセット
     act(() => {
       result.current.resetToDefault();
     });
 
-    expect(result.current.currentKey.tonic.sharpName).toBe('C');
+    expect(result.current.currentKey.centerPitch.sharpName).toBe('C');
     expect(result.current.currentKey.isMajor).toBe(true);
   });
 


### PR DESCRIPTION
<!-- レビューは日本語で行うこと -->

# Overview

ドメイン層をリファクタリングし、調性(Tonal)と旋法(Modal)の両方の音楽的文脈を抽象的に扱えるように `IMusicalContext` インターフェースを導入しました。これにより、今後の旋法（モード）機能の拡張性が向上します。

## Related Issues

- Closes #

## Changes

- `IMusicalContext` インターフェースを導入し、音楽的文脈の共通契約を定義
- `Key` 集約をリファクタリングし、`IMusicalContext` を実装。生成にはファクトリーメソッド (`Key.major()`, `Key.minor()`) を使用するように変更
- 将来的な旋法システム対応のため、`ModalContext` をプレースホルダーとして追加
- 新しいドメインAPIに合わせて、関連するテスト、Storybook、ストア、フックをすべて更新
- ドメイン設計ドキュメント (`docs/04.domainSystem.md`) を新しいアーキテクチャに合わせて更新

## Type of Change

- [x] ✨ New feature (a non-breaking change which adds functionality)
- [x] ♻️ Refactoring (a code change that neither fixes a bug nor adds a feature)
- [ ] 🐛 Bug fix (a non-breaking change which fixes an issue)
- [ ] 📚 Documentation update
- [ ] ⚙️ Other (please describe):

## Screenshots

UIの変更はありません。

## Self-Review Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Additional Comments

